### PR TITLE
fix: default_url_options for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,7 +100,7 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
-  config.action_mailer.default_url_options = { host: 'mina.fly.dev', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: "mina.fly.dev", protocol: "https" }
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,7 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
+  config.action_mailer.default_url_options = { host: 'mina.fly.dev', protocol: 'https' }
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
本番環境でパスワードリセットメールが送れるように以下の修正を加えました。

- config/environments/production.rb にある default_url_optionsを
`config.action_mailer.default_url_options = { host: 'mina.fly.dev', protocol: 'https' }`
に修正