### PR TITLE
fix: 本番環境パスワードリセットメール

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,7 +100,20 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
-  config.action_mailer.default_url_options = { host: "mina.fly.dev", protocol: "https" }
+  config.action_mailer.default_url_options = { host: ENV['APP_HOST'], protocol: "https" }
+
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    port: ENV['SMTP_PORT'].to_i,
+    address: ENV['SMTP_ADDRESS'],
+    domain: ENV['SMTP_DOMAIN'],
+    user_name: ENV['SMTP_USERNAME'], #Gmailアカウントのメールアドレス
+    password: ENV['SMTP_PASSWORD'], #Gmailで設定したアプリパスワード
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,11 +105,11 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    port: ENV['SMTP_PORT'].to_i,
-    address: ENV['SMTP_ADDRESS'],
-    domain: ENV['SMTP_DOMAIN'],
-    user_name: ENV['SMTP_USERNAME'], #Gmailアカウントのメールアドレス
-    password: ENV['SMTP_PASSWORD'], #Gmailで設定したアプリパスワード
+    port: ENV["SMTP_PORT"].to_i,
+    address: ENV["SMTP_ADDRESS"],
+    domain: ENV["SMTP_DOMAIN"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
     authentication: :plain,
     enable_starttls_auto: true
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,7 +100,7 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
-  config.action_mailer.default_url_options = { host: ENV['APP_HOST'], protocol: "https" }
+  config.action_mailer.default_url_options = { host: ENV["APP_HOST"], protocol: "https" }
 
   config.action_mailer.delivery_method = :smtp
 


### PR DESCRIPTION
以下の手順で本番環境でパスワードリセットメールが送れるように修正しました。

1. Gmail新規アカウント作成
2. GmailでSMTPサーバーの設定を行う（二段階認証、アプリパスワード）
3. config/environments/production.rbへ、本番環境でのメール設定の記述をする
4. 環境変数をFly.ioに直接指定する


