### PR TITLE
add: クリニック位置情報機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@
 /.bundle
 
 # Ignore all environment files (except templates).
-/.env*
-!/.env*.erb
+/.env
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "importmap-rails"
 gem "pry-rails"
 gem "ransack", ">= 3.3.0"
 gem "config", "4.0.0"
+gem "geocoder"
+gem "dotenv-rails"
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,12 +117,17 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.2)
     date (3.4.0)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
+    dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     dry-configurable (1.3.0)
       dry-core (~> 1.1)
@@ -173,6 +178,9 @@ GEM
     ffi (1.17.0-x86-linux-gnu)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -431,6 +439,8 @@ DEPENDENCIES
   config (= 4.0.0)
   cssbundling-rails
   debug
+  dotenv-rails
+  geocoder
   importmap-rails
   jbuilder
   jsbundling-rails

--- a/app/controllers/clinics_controller.rb
+++ b/app/controllers/clinics_controller.rb
@@ -48,7 +48,7 @@ class ClinicsController < ApplicationController
   private
 
   def clinic_params
-    params.require(:clinic).permit(:clinic_name, :doctor_name, :url,
+    params.require(:clinic).permit(:clinic_name, :doctor_name, :url, :address,
     available_times_attributes: [ :id, :available_time_slot, :weekday ],
     visit_intervals_attributes: [ :id, :interval ]
   )

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -13,6 +13,9 @@ class Clinic < ApplicationRecord
   before_validation :assign_user_to_available_times
   before_validation :assign_user_to_visit_intervals
 
+  geocoded_by :address, latitude: :latitude, longitude: :longitude  # 住所をもとに緯度・経度を取得
+  after_validation :geocode, if: ->(obj){ obj.address.present? }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[clinic_name]
   end

--- a/app/views/clinics/edit.html.erb
+++ b/app/views/clinics/edit.html.erb
@@ -15,9 +15,16 @@
           <%= f.text_field :doctor_name, class: "form-control" %>
         </div>
 
+        <!-- クリニックホームページURL -->
         <div class="mb-3">
 	        <%= f.label :url, "URL" %>
 	        <%= f.text_field :url, class: "form-control" %>
+        </div>
+
+        <!-- 住所 -->
+        <div class="mb-3">
+          <%= f.label :address, "住所" %>
+          <%= f.text_field :address, class: "form-control" %>
         </div>
 
         <!-- 面会可能日時 -->

--- a/app/views/clinics/new.html.erb
+++ b/app/views/clinics/new.html.erb
@@ -15,9 +15,16 @@
           <%= f.text_field :doctor_name, class: "form-control" %>
         </div>
 
+        <!-- クリニックホームページurl -->
         <div class="mb-3">
 	        <%= f.label :url, "URL" %>
 	        <%= f.text_field :url, class: "form-control" %>
+        </div>
+
+        <!-- 住所 -->
+        <div class="mb-3">
+          <%= f.label :address, "住所" %>
+          <%= f.text_field :address, class: "form-control" %>
         </div>
 
         <%= f.fields_for :available_times do |at| %>

--- a/app/views/clinics/show.html.erb
+++ b/app/views/clinics/show.html.erb
@@ -24,6 +24,42 @@
           <!-- 基本情報 -->
           <p class="text-muted"><strong>ホームページ:</strong> <%= @clinic.url %></p>
           <p class="text-muted"><strong>院長名:</strong> <%= @clinic.doctor_name %></p>
+          <p class="text-muted"><strong>住所:</strong> <%= @clinic.address %></p>
+
+          <!-- Googleマップ表示エリア(地図を表示) -->
+          <div id="map"style="height: 600px;"></div>
+          
+          <!-- Googleマップ表示用の Javascript -->
+          <script>
+            function initMap(){
+              // 地図の位置情報(緯度・経度)を取得
+              let mapPosition = {lat: <%= @clinic.latitude || 0 %> , lng: <%= @clinic.longitude || 0 %> };
+              let map = new google.maps.Map(document.getElementById('map'), {
+                zoom: 15,
+                center: mapPosition
+              });
+              let transitLayer = new google.maps.TransitLayer();
+              transitLayer.setMap(map);
+          
+              let contentString = '【住所】<%= @clinic.address %>';
+              let infowindow = new google.maps.InfoWindow({
+                content: contentString
+              });
+          
+              let marker = new google.maps.Marker({
+                position: mapPosition,
+                map: map,
+                title: contentString
+              });
+          
+              marker.addListener('click', function(){
+                infowindow.open(map, marker);
+              });
+            }
+            </script>
+          
+            <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>
+
           <hr>
 
           <!-- 面会時間 -->

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,19 @@
+Geocoder.configure(
+  # Google Maps API を使用
+  lookup: :google,
+  
+  # Google Maps API キーを環境変数から取得
+  api_key: ENV['GOOGLE_MAP_API_KEY'],
+  
+  # HTTPS 通信を使用
+  use_https: true,
+  
+  # タイムアウト（秒）
+  timeout: 5,
+  
+  # 緯度・経度の単位 (km or miles)
+  units: :km,
+  
+  # レスポンスの言語設定を日本語に
+  language: :ja
+)

--- a/db/migrate/20250309030240_add_location_to_clinics.rb
+++ b/db/migrate/20250309030240_add_location_to_clinics.rb
@@ -1,0 +1,7 @@
+class AddLocationToClinics < ActiveRecord::Migration[7.2]
+  def change
+    add_column :clinics, :address, :string
+    add_column :clinics, :latitude, :decimal
+    add_column :clinics, :longitude, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_25_020553) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_09_030240) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_25_020553) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "url"
+    t.string "address"
+    t.decimal "latitude"
+    t.decimal "longitude"
     t.index ["user_id"], name: "index_clinics_on_user_id"
   end
 


### PR DESCRIPTION
以下の手順でクリニック位置情報（google map）を表示する機能を追加しました。

1. googlemapAPIを取得する→geocording、map javascript apiの有効化
2. 緯度・経度を保存するカラムを追加
3. クリニック登録・編集画面に住所欄を追加
4. gem “geocoder”をインストール
5. clinicモデルにgeocoderの設定を追記
6. config/initializers/geocoder.rbの作成・編集
7. .envファイルの作成・編集
8. gem ‘dotenv-rails’のインストール
9. .gitignoreファイルを編集
10. クリニック詳細外面に地図を表示させるjavascriptを追記