### PR TITLE
fix: APIkey

### DIFF
--- a/app/views/clinics/show.html.erb
+++ b/app/views/clinics/show.html.erb
@@ -56,9 +56,9 @@
                 infowindow.open(map, marker);
               });
             }
-            </script>
+          </script>
           
-            <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>
+          <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap" async defer></script>
 
           <hr>
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -3,7 +3,7 @@ Geocoder.configure(
   lookup: :google,
 
   # Google Maps API キーを環境変数から取得
-  api_key: ENV["GOOGLE_MAP_API_KEY"],
+  api_key: ENV["GOOGLE_MAPS_API_KEY"],
 
   # HTTPS 通信を使用
   use_https: true,


### PR DESCRIPTION
環境変数の書き方を、ENV["GOOGLE_MAPS_API_KEY"]に統一する修正を加えました。